### PR TITLE
Added command line version for /usr/local/bin

### DIFF
--- a/drivedirect
+++ b/drivedirect
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+
+try:
+    link = sys.argv[1]
+    downloadLink = link.replace('file/d/', 'uc?export=download&id=')
+    downloadLink = downloadLink.replace('/view?usp=sharing', '')
+
+    print('Your URL is', downloadLink)
+except:
+    print('Command usage: drivedirect "[url]"')


### PR DESCRIPTION
## Added a new file named "drivedirect"

You can copy it to /usr/local/bin to directly create an URL using `drivedirect "[url]"` (" is important because zsh doesn't like the "?" in the URL)

If you copied the file you can use the command from everywhere (every directory)

## Features that can be added later: 
- auto-install to /usr/local/bin
- fix the "?" issue with zsh